### PR TITLE
Pass context to serializers

### DIFF
--- a/drf_multiple_model/mixins.py
+++ b/drf_multiple_model/mixins.py
@@ -1,4 +1,4 @@
-from rest_framework.response import Response 
+from rest_framework.response import Response
 
 from itertools import chain
 
@@ -63,14 +63,15 @@ class MultipleModelMixin(object):
             queryset = self.filter_queryset(pair[0])
 
             # Run the paired serializer
-            data = pair[1](queryset,many=True).data
+            context = self.get_serializer_context()
+            data = pair[1](queryset,many=True,context=context).data
 
             # Get the label, unless add_model_type is note set
             try:
                 label = pair[2]
             except IndexError:
                 if self.add_model_type:
-                    label = queryset.model.__name__.lower() 
+                    label = queryset.model.__name__.lower()
                 else:
                     label = None
 
@@ -80,7 +81,7 @@ class MultipleModelMixin(object):
                     if label:
                         datum.update({'type':label})
                     results.append(datum)
-            
+
             # Otherwise, group the data by Model/Queryset
             else:
                 if label:
@@ -89,12 +90,10 @@ class MultipleModelMixin(object):
                 results.append(data)
 
 
-                
+
         # Sort by given attribute, if sorting_attribute is provided
         if self.sorting_field and self.flat:
             results = sorted(results, key=lambda datum: datum[self.sorting_field])
 
 
         return Response(results)
-
-

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,8 @@
 import os
 from setuptools import setup
 
-with open(os.path.join(os.path.dirname(__file__), 'PYPI_README.rst')) as readme:
-    README = readme.read()
+# with open(os.path.join(os.path.dirname(__file__), 'PYPI_README.rst')) as readme:
+#     README = readme.read()
 
 # allow setup.py to be run from any path
 os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
@@ -12,9 +12,9 @@ setup(
     version='1.2',
     packages=['drf_multiple_model'],
     include_package_data=True,
-    license='MIT License',  
+    license='MIT License',
     description='Multiple model/queryset view (and mixin) for Django Rest Framework',
-    long_description=README,
+    #long_description=README,
     url='https://github.com/Axiologue/DjangoRestMultipleModels',
     author='Matt Broach',
     author_email='go.for.dover@gmail.com',
@@ -22,7 +22,7 @@ setup(
         'Environment :: Web Environment',
         'Framework :: Django',
         'Intended Audience :: Developers',
-        'License :: OSI Approved :: MIT License', 
+        'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',


### PR DESCRIPTION
I needed to pass data to the serializer and noticed that the multiple models view doesn't pass the context to the serializers the way the rest framework view sets do. Not sure if this is an oversight or if I missed something? With the following adjustment I was able to achieve what I wanted.

(I had to make a change to setup.py to make the package installable from Github; there seems to be a README file missing. So you might not want to merge my pull request as it is.)