### PR TITLE
Add `sort_descending` attribute and break out sort into own function

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,8 @@ would return:
 ]
 ```
 
+You can reverse the order using the attribute `sort_descending = True`.
+
 **WARNING:** the field chosen for ordering must be shared by all models/serializers in your queryList.  Any attempt to sort objects along non_shared fields with throw a `KeyError`.
 
 ### add_model_type

--- a/drf_multiple_model/mixins.py
+++ b/drf_multiple_model/mixins.py
@@ -40,6 +40,9 @@ class MultipleModelMixin(object):
     # note that the attribute must by shared by ALL models
     sorting_field = None
 
+    # Sort order for sorting_field
+    sort_descending = False
+
     # Flag to append the particular django model being used to the data
     add_model_type = True
 
@@ -105,7 +108,7 @@ class MultipleModelMixin(object):
         if self.flat:
             # Sort by given attribute, if sorting_attribute is provided
             if self.sorting_field:
-                results = sorted(results, key=lambda datum: datum[self.sorting_field])
+                results = self.sort(results)
             
             # Return paginated results if pagination is enabled
             page = self.paginate_queryList(results)
@@ -116,6 +119,9 @@ class MultipleModelMixin(object):
             return Response({'data': results})
 
         return Response(results)
+
+    def sort(self, results):
+        return sorted(results, reverse=self.sort_descending, key=lambda datum: datum[self.sorting_field])
 
 
 class Query(object):

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
     name='django-rest-multiple-models',
-    version='1.6.1',
+    version='1.6.2',
     packages=['drf_multiple_model'],
     include_package_data=True,
     license='MIT License',


### PR DESCRIPTION
A reverse option was already built in to sorted(), the separate function makes extending it easier.

New to Django (just hacking on an existing project) and I honestly couldn't get the test suite to run so I didn't bother writing one. If you're willing to accept this PR you may want to at least quickly confirm all tests still pass. (Not sure if a new one is needed since again reverse was built-in.)

Thanks!