### PR TITLE
Pagination for `objectify` implementation and fix flat=True and objectify=True usage

### DIFF
--- a/drf_multiple_model/mixins.py
+++ b/drf_multiple_model/mixins.py
@@ -99,6 +99,7 @@ class MultipleModelMixin(object):
             if page is not None:
                 return self.get_paginated_response(page)
 
+
         if request.accepted_renderer.format == 'html':
             return Response({'data': results})
 
@@ -115,7 +116,7 @@ class MultipleModelMixin(object):
                 label = query.queryset.model.__name__.lower()
 
         # if flat=True, Organize the data in a flat manner
-        if self.flat:
+        if self.flat and not self.objectify:
             for datum in new_data:
                 if label:
                     datum.update({'type': label})

--- a/drf_multiple_model/mixins.py
+++ b/drf_multiple_model/mixins.py
@@ -115,8 +115,11 @@ class MultipleModelMixin(object):
             if self.add_model_type:
                 label = query.queryset.model.__name__.lower()
 
+        if self.flat and self.objectify:
+            raise RuntimeError("Cannot objectify data with flat=True. Try to use objectify=False")
+
         # if flat=True, Organize the data in a flat manner
-        if self.flat and not self.objectify:
+        elif self.flat:
             for datum in new_data:
                 if label:
                     datum.update({'type': label})


### PR DESCRIPTION
Hi, Matt!

1. If flat and objectify params set as True,  DjangoRestMultipleModels tried to append datum to the dict "result" through usage "append" method. Obviously use objectify=True and flat=True together is an incorrect approach, i've add checking this.

2. We use pagination only for certain querysets (such as listing results) and we should't paginate additional querysets (such as filters, features for results, etc). So I see no reason to maintain our own approach for this and add it to code. 